### PR TITLE
Copy workloads to an output folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "format:packages": "pnpm -F './packages/**' format",
     "build:apps": "pnpm -F './apps/**' build:static",
-    "build:packages": "pnpm -F './packages/**' build"
+    "build:packages": "pnpm -F './packages/**' build",
+    "move:apps": "OUTPUT='../../../.workloads' pnpm -F workloads-manager move",
+    "move:apps:desktop": "OUTPUT='~/Desktop/workloads' pnpm -F workloads-manager move"
   },
   "keywords": [],
   "author": "",

--- a/packages/tools/workloads-manager/package.json
+++ b/packages/tools/workloads-manager/package.json
@@ -18,6 +18,7 @@
     "build": "rollup -c --bundleConfigAsCjs",
     "build:apps": "TYPE='static' node scripts/build.js",
     "connect": "DATA='./workloads.config.json' node scripts/connect.js",
+    "move": "DATA='./workloads.config.folder.json' node scripts/move.js",
     "start:domain": "DATA='./workloads.config.domain.json' node scripts/start.domain.js",
     "start:folder": "DATA='./workloads.config.folder.json' node scripts/start.folder.js",
     "start:ports": "DATA='./workloads.config.ports.json' node scripts/start.ports.js",

--- a/packages/tools/workloads-manager/scripts/move.js
+++ b/packages/tools/workloads-manager/scripts/move.js
@@ -1,0 +1,90 @@
+const fs = require("fs-extra");
+const path = require("path");
+
+const { findDirectoriesByName, getHomeDirectory } = require("./utils");
+
+/**
+ * createDirectory
+ *
+ * Removes and recreates a directory.
+ *
+ * @param {string} directory Directory name.
+ */
+async function createDirectory(directory) {
+    await fs.rm(directory, { recursive: true, force: true });
+    await fs.mkdir(directory);
+}
+
+/**
+ * copyDirectory
+ *
+ * Copies a source folder to a destination folder.
+ *
+ * @param {string} src Source directory.
+ * @param {string} dest Destination directory.
+ */
+async function copyDirectory(src, dest) {
+    await fs.cp(src, dest, { recursive: true }, (err) => {
+        if (err) console.error(err);
+    });
+}
+
+async function moveWorkload({ workload, start, output }) {
+    // Name of the root directory - "aurora-workloads".
+    const root = path.basename(path.resolve(start));
+
+    const { name, distDirectory = "/dist" } = workload;
+
+    const results = await findDirectoriesByName({
+        start,
+        target: name,
+        root,
+    });
+
+    const directory = results[0];
+
+    const src = `${directory}${distDirectory}`;
+    const dest = `${output}/${name}`;
+
+    await createDirectory(dest);
+    await copyDirectory(src, dest);
+}
+
+async function moveWorkloads() {
+    // We're starting from the root directory of the monorepo.
+    const start = "../../../";
+
+    /**
+     * Location of the output folder, where all workloads get moved to.
+     * If an OUTPUT was passed in that's located inside the aurora-workloads repo, please ensure that the OUTPUT gets added to the exclude list, when searching for directories:
+     * ./utils.js / excludeList
+     *
+     * IF no OUTPUT was passed in, the default location is a folder called '.workloads' in the root of the repository ('aurora-workloads/.workloads').
+     */
+    let outputName = process.env.OUTPUT ?? `${start}.workloads`;
+
+    if (outputName.charAt(0) === "~") {
+        outputName = outputName.replace("~", getHomeDirectory())
+    }
+
+    // Ensure node can find the output path.
+    const output = path.resolve(outputName);
+
+    if (!process.env.DATA) {
+        throw Error("No data file passed in!");
+    }
+
+    await createDirectory(output);
+
+    const { workloads } = JSON.parse(
+        fs.readFileSync(process.env.DATA, "utf-8")
+    );
+
+    for (const workload of workloads) {
+        await moveWorkload({ workload, start, output });
+    }
+
+    console.log("Done!");
+}
+
+moveWorkloads();

--- a/packages/tools/workloads-manager/scripts/move.js
+++ b/packages/tools/workloads-manager/scripts/move.js
@@ -11,8 +11,8 @@ const { findDirectoriesByName, getHomeDirectory } = require("./utils");
  * @param {string} directory Directory name.
  */
 async function createDirectory(directory) {
-    await fs.rm(directory, { recursive: true, force: true });
-    await fs.mkdir(directory);
+  await fs.rm(directory, { recursive: true, force: true });
+  await fs.mkdir(directory);
 }
 
 /**
@@ -24,77 +24,75 @@ async function createDirectory(directory) {
  * @param {string} dest Destination directory.
  */
 async function copyDirectory(src, dest) {
-    await fs.cp(src, dest, { recursive: true }, (err) => {
-        if (err) console.error(err);
-    });
+  await fs.cp(src, dest, { recursive: true }, (err) => {
+    if (err) console.error(err);
+  });
 }
 
 /**
  * moveWorkload
- * 
+ *
  * Copies dist files of a workload to an output folder.
- * 
+ *
  * @param {Object} config - Config object for function to run.
  * @param {Object} config.workloads - Workloads from workloads.config.json file.
  * @param {string} config.start - Start folder to use for discovering workloads folders.
  * @param {string} config.output - Output folder to use.
  */
 async function moveWorkload({ workload, start, output }) {
-    // Name of the root directory - "aurora-workloads".
-    const root = path.basename(path.resolve(start));
+  // Name of the root directory - "aurora-workloads".
+  const root = path.basename(path.resolve(start));
 
-    const { name, distDirectory = "/dist" } = workload;
+  const { name, distDirectory = "/dist" } = workload;
 
-    const results = await findDirectoriesByName({
-        start,
-        target: name,
-        root,
-    });
+  const results = await findDirectoriesByName({
+    start,
+    target: name,
+    root,
+  });
 
-    const directory = results[0];
+  const directory = results[0];
 
-    const src = `${directory}${distDirectory}`;
-    const dest = `${output}/${name}`;
+  const src = `${directory}${distDirectory}`;
+  const dest = `${output}/${name}`;
 
-    await createDirectory(dest);
-    await copyDirectory(src, dest);
+  await createDirectory(dest);
+  await copyDirectory(src, dest);
 }
 
 async function moveWorkloads() {
-    // We're starting from the root directory of the monorepo.
-    const start = "../../../";
+  // We're starting from the root directory of the monorepo.
+  const start = "../../../";
 
-    /**
-     * Location of the output folder, where all workloads get moved to.
-     * If an OUTPUT was passed in that's located inside the aurora-workloads repo, please ensure that the OUTPUT gets added to the exclude list, when searching for directories:
-     * ./utils.js / excludeList
-     *
-     * IF no OUTPUT was passed in, the default location is a folder called '.workloads' in the root of the repository ('aurora-workloads/.workloads').
-     */
-    let outputName = process.env.OUTPUT ?? `${start}.workloads`;
+  /**
+   * Location of the output folder, where all workloads get moved to.
+   * If an OUTPUT was passed in that's located inside the aurora-workloads repo, please ensure that the OUTPUT gets added to the exclude list, when searching for directories:
+   * ./utils.js / excludeList
+   *
+   * IF no OUTPUT was passed in, the default location is a folder called '.workloads' in the root of the repository ('aurora-workloads/.workloads').
+   */
+  let outputName = process.env.OUTPUT ?? `${start}.workloads`;
 
-    if (outputName.charAt(0) === "~") {
-        outputName = outputName.replace("~", getHomeDirectory())
-    }
+  if (outputName.charAt(0) === "~") {
+    outputName = outputName.replace("~", getHomeDirectory());
+  }
 
-    // Ensure node can find the output path.
-    const output = path.resolve(outputName);
+  // Ensure node can find the output path.
+  const output = path.resolve(outputName);
 
-    if (!process.env.DATA) {
-        throw Error("No data file passed in!");
-    }
+  if (!process.env.DATA) {
+    throw Error("No data file passed in!");
+  }
 
-    await createDirectory(output);
+  await createDirectory(output);
 
-    const { workloads } = JSON.parse(
-        fs.readFileSync(process.env.DATA, "utf-8")
-    );
+  const { workloads } = JSON.parse(fs.readFileSync(process.env.DATA, "utf-8"));
 
-    for (const workload of workloads) {
-        await moveWorkload({ workload, start, output });
-    }
+  for (const workload of workloads) {
+    await moveWorkload({ workload, start, output });
+  }
 
-    console.log("Done!");
+  console.log("Done!");
 }
 
 moveWorkloads();

--- a/packages/tools/workloads-manager/scripts/move.js
+++ b/packages/tools/workloads-manager/scripts/move.js
@@ -29,6 +29,16 @@ async function copyDirectory(src, dest) {
     });
 }
 
+/**
+ * moveWorkload
+ * 
+ * Copies dist files of a workload to an output folder.
+ * 
+ * @param {Object} config - Config object for function to run.
+ * @param {Object} config.workloads - Workloads from workloads.config.json file.
+ * @param {string} config.start - Start folder to use for discovering workloads folders.
+ * @param {string} config.output - Output folder to use.
+ */
 async function moveWorkload({ workload, start, output }) {
     // Name of the root directory - "aurora-workloads".
     const root = path.basename(path.resolve(start));

--- a/packages/tools/workloads-manager/scripts/utils.js
+++ b/packages/tools/workloads-manager/scripts/utils.js
@@ -2,7 +2,7 @@ const fs = require("fs").promises;
 const path = require("path");
 const { exec, execSync } = require("child_process");
 const chalk = require("chalk");
-const { homedir } = require('os');
+const { homedir } = require("os");
 
 const excludeList = [
   ".angular",
@@ -167,7 +167,7 @@ async function executeScript({ script, directory, env = {} }) {
 
 function getHomeDirectory() {
   const homeDirectory = homedir();
-  return homeDirectory
+  return homeDirectory;
 }
 
 module.exports = {
@@ -175,5 +175,5 @@ module.exports = {
   findDirectoriesByName,
   executeScript,
   executeScriptSync,
-  getHomeDirectory
+  getHomeDirectory,
 };


### PR DESCRIPTION
Manual integration for speedometer:

This pr enables a script to copy all workload dist folders to one output folder, with the following structure:

```
.
└── workloads/
    ├── charts-chartjs
    ├── news-site-next
    ├── editors-tiptap
    ├── todomvc-angular
    └── todomvc-backbone-complex
```

Steps to integrate with Speedometer:
1. clone aurora-workloads
2. pnpm install
3. pnpm run move:all:desktop (creates a workloads folder on your desktop)
4. manually move folder into Speedometer repo (root)
5. benchmark-runner.mjs - _preapareSuite - frame.src = suite.url 
6. tests.mjs: disable react stockcharts and perf dashboard (not yet supported)
7. tests.mjs: update urls similar to: `url: "workloads/news-site-next",`
8. run
@kara 